### PR TITLE
Use the gemparser service to parse Podfiles

### DIFF
--- a/lib/parsers/cocoapods.js
+++ b/lib/parsers/cocoapods.js
@@ -1,11 +1,25 @@
 'use strict';
 
+var rp = require('request-promise');
+
 var cocoapods = function(str) {
-  return str.split("\n").reduce(function(accum,line) {
-    var match = line.replace(/'|"/g,'').match(/pod ([a-zA-Z-_]+)(,\s?(.+)?)?/i);
-    if (match) accum.push([match[1], match[3] || '>= 0']);
-    return accum;
-  }, []);
+  var options = {
+    uri :     'https://gemparser.herokuapp.com/podfile',
+    method :  'POST',
+    formData: {body: str}
+  };
+
+  return rp(options)
+  .then( (res) => {
+    let packages;
+    try { packages = JSON.parse(res); } catch(err) { return []; }
+
+    return Object.keys(packages)
+    .reduce(function(accum, pkg) {
+      accum.push([pkg, packages[pkg]]);
+      return accum;
+    }, []);
+  });
 };
 
 module.exports = cocoapods;

--- a/test/fixtures/Podfile
+++ b/test/fixtures/Podfile
@@ -1,2 +1,74 @@
 source 'https://github.com/CocoaPods/Specs.git'
-pod 'AFNetworking', '~> 1.0'
+source 'https://github.com/artsy/Specs.git'
+
+plugin 'cocoapods-keys', {
+  :project => 'Eidolon',
+  :keys => [
+    'ArtsyAPIClientSecret',
+    'ArtsyAPIClientKey',
+    'HockeyProductionSecret',
+    'HockeyBetaSecret',
+    'MixpanelProductionAPIClientKey',
+    'MixpanelStagingAPIClientKey',
+    'CardflightProductionAPIClientKey',
+    'CardflightProductionMerchantAccountToken',
+    'StripeProductionPublishableKey',
+    'CardflightStagingAPIClientKey',
+    'CardflightStagingMerchantAccountToken',
+    'StripeStagingPublishableKey'
+  ]
+}
+
+platform :ios, '8.0'
+use_frameworks!
+
+# Yep.
+inhibit_all_warnings!
+
+# Artsy stuff
+pod 'Artsy+UIColors'
+pod 'Artsy+UILabels'
+pod 'Artsy-UIButtons'
+
+if ['orta', 'ash', 'artsy', 'Laura', 'CI', 'distiller', 'travis'].include?(ENV['USER'])
+    pod 'Artsy+UIFonts', '~> 1.1.0'
+else
+    pod 'Artsy+OSSUIFonts', '~> 1.1.0'
+end
+
+pod 'ORStackView'
+pod 'FLKAutoLayout'
+pod 'ISO8601DateFormatter', '0.7'
+pod 'ARCollectionViewMasonryLayout', '~> 2.0.0'
+pod 'SDWebImage', '~> 3.7'
+pod 'SVProgressHUD'
+
+pod 'ARAnalytics/Mixpanel'
+pod 'ARAnalytics/HockeyApp'
+
+pod 'CardFlight'
+pod 'Stripe'
+pod 'ECPhoneNumberFormatter'
+pod 'UIImageViewAligned', :git => 'https://github.com/ashfurrow/UIImageViewAligned.git'
+pod 'DZNWebViewController', :git => 'https://github.com/orta/DZNWebViewController.git'
+pod 'Reachability', :git => 'https://github.com/ashfurrow/Reachability.git', :branch => 'frameworks'
+
+pod 'UIView+BooleanAnimations'
+pod 'ARTiledImageView', :git => 'https://github.com/ashfurrow/ARTiledImageView.git'
+pod 'XNGMarkdownParser'
+
+# Swift pods
+pod 'SwiftyJSON', :git => 'https://github.com/SwiftyJSON/SwiftyJSON.git', :branch => 'xcode7'
+pod 'ReactiveCocoa', '~> 4.0.1-alpha-2'
+pod 'Moya/ReactiveCocoa'
+pod 'Swift-RAC-Macros'
+
+target 'KioskTests' do
+
+  pod 'FBSnapshotTestCase'
+  pod 'Nimble-Snapshots'
+  pod 'Quick'
+  pod 'Nimble', '= 2.0.0-rc.3'
+  pod 'Forgeries'
+
+end

--- a/test/parsers_test.js
+++ b/test/parsers_test.js
@@ -135,7 +135,7 @@ var platformTests = [
   {
     platform: 'cocoapods',
     fixture: 'Podfile',
-    expected: [['AFNetworking', '~> 1.0']],
+    expected: [['Artsy-UIButtons', '>= 0']],
     validManifestPaths: ['Podfile'],
     invalidManifestPaths: []
   },


### PR DESCRIPTION
I've added support for parsing deps out of podfiles to the gemnasium-parser here: https://github.com/librariesio/gemnasium-parser/commit/672f0938cab6d6b3825c5212003654f8c7e5a8b6

and then used it in the gemparser sinatra app here: https://github.com/librariesio/gem_parser/commit/d98deac657154a35fca73449f5da2b264124eebb

and added a more complex example of a Podfile to boot.

Closes https://github.com/librariesio/librarian/issues/43
